### PR TITLE
Add option for `parse` to use headers for cache key

### DIFF
--- a/lib/routebox.js
+++ b/lib/routebox.js
@@ -16,6 +16,7 @@ const schema = Joi.object({
         query: Joi.bool(),
         method: Joi.bool(),
         route: Joi.bool(),
+        headers: Joi.object(),
     }).required(),
     callback: Joi.object().required().keys({
         onCacheHit: Joi.func().required(),
@@ -36,6 +37,7 @@ routebox.register = function (server, options, next) {
             query: true,
             method: true,
             route: true,
+            headers: {},
         },
         callback: {
             onCacheHit: reqNoop,
@@ -115,6 +117,10 @@ routebox.register = function (server, options, next) {
             method: settings.parse.method && req.method,
             query: settings.parse.query && req.query,
             route: settings.parse.route && req.path,
+            headers: Object.keys(settings.parse.headers || {}).reduce((headersHash, name) => {
+                headersHash[name] = settings.parse.headers[name] && req.headers[name];
+                return headersHash;
+            }, {}),
         }, settings.digest);
 
         const policy = pick(settings, ['cache', 'segment', 'expiresIn', 'expiresAt']);

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ These options are available when routebox is registered and can also be overridd
     * `query` whether to include the query string. Defaults to `true`.
     * `method` whether to include the request method. Defaults to `true`.
     * `route` whether to include the route path. Defaults to `true`.
+    * `headers` an object with keys that are the headers to include. Defaults to `{}`.
  * `callbacks` provides touch-points you can use to intercept the request and gather metrics. Each callback functions like a Hapi extension, taking the `(request, reply)` as arguments, after which you should call `reply.continue()`. These are called at the `onPreResponse` lifecycle point.
     * `onCacheHit` is called when a cached page is served.
     * `onCacheMiss` is called when a page that could be cached but is not (yet) is served.

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ These options are available when routebox is registered and can also be overridd
  * `parse` configures which parts of the request will be used to form the cache key:
     * `query` whether to include the query string. Defaults to `true`.
     * `method` whether to include the request method. Defaults to `true`.
-    * `path` whether to include the route path. Defaults to `true`.
+    * `route` whether to include the route path. Defaults to `true`.
  * `callbacks` provides touch-points you can use to intercept the request and gather metrics. Each callback functions like a Hapi extension, taking the `(request, reply)` as arguments, after which you should call `reply.continue()`. These are called at the `onPreResponse` lifecycle point.
     * `onCacheHit` is called when a cached page is served.
     * `onCacheMiss` is called when a page that could be cached but is not (yet) is served.

--- a/test/routebox.test.js
+++ b/test/routebox.test.js
@@ -233,4 +233,103 @@ describe('routebox', function () {
             });
         });
     });
+
+    it('respects config.plugins.routebox.parse.query = false', function(done) {
+        server.route({
+            method: 'get', path: '/a',
+            config: {
+                cache: { expiresIn: 1000 },
+                handler: (req, reply) => {
+                    reply(i++);
+                },
+                plugins: {
+                    routebox: {
+                        parse: {
+                            query: false,
+                        },
+                    },
+                },
+            },
+        });
+
+        var i = 0;
+        server.inject({ method: 'GET', url: '/a?=0' }, (res) => {
+            expect(res.result).to.equal(0);
+            expect(res.statusCode).to.equal(200);
+            assertNotCached(res);
+
+            server.inject({ method: 'GET', url: '/a?=1' }, (res2) => {
+                expect(res2.result).to.equal(0);
+                expect(res2.statusCode).to.equal(200);
+                assertCached(res2);
+                done();
+            });
+        });
+    });
+
+    it('respects config.plugins.routebox.parse.route = false', function(done) {
+        server.route({
+            method: 'get', path: '/a/{b}',
+            config: {
+                cache: { expiresIn: 1000 },
+                handler: (req, reply) => {
+                    reply(i++);
+                },
+                plugins: {
+                    routebox: {
+                        parse: {
+                            route: false,
+                        },
+                    },
+                },
+            },
+        });
+
+        var i = 0;
+        server.inject({ method: 'GET', url: '/a/x' }, (res) => {
+            expect(res.result).to.equal(0);
+            expect(res.statusCode).to.equal(200);
+            assertNotCached(res);
+
+            server.inject({ method: 'GET', url: '/a/y' }, (res2) => {
+                expect(res2.result).to.equal(0);
+                expect(res2.statusCode).to.equal(200);
+                assertCached(res2);
+                done();
+            });
+        });
+    });
+
+    it('respects config.plugins.routebox.parse.method = false', function(done) {
+        server.route({
+            method: ['put', 'get'], path: '/a',
+            config: {
+                cache: { expiresIn: 1000 },
+                handler: (req, reply) => {
+                    reply(i++);
+                },
+                plugins: {
+                    routebox: {
+                        parse: {
+                            method: false,
+                        },
+                    },
+                },
+            },
+        });
+
+        var i = 0;
+        server.inject({ method: 'PUT', url: '/a' }, (res) => {
+            expect(res.result).to.equal(0);
+            expect(res.statusCode).to.equal(200);
+            assertNotCached(res);
+
+            server.inject({ method: 'GET', url: '/a' }, (res2) => {
+                expect(res2.result).to.equal(0);
+                expect(res2.statusCode).to.equal(200);
+                assertCached(res2);
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
Add feature to specify headers to be used in the cache key. By default no header values are used in the cache key - opt in only.

```javascript
plugins: {
  routebox: {
    parse: {
      headers: {
        'accept-language': true, // lowercase because Hapi converts names to lowercase
      }
    },
  },
}
```